### PR TITLE
[Chore] add test cases

### DIFF
--- a/src/test/hooks/useCanvasTransform.test.ts
+++ b/src/test/hooks/useCanvasTransform.test.ts
@@ -1,0 +1,279 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCanvasTransform } from '../../hooks/useCanvasTransform';
+import type { DiagramNode } from '../../types';
+
+// 800×600 canvas, dpr=1 → logical centre (400, 300)
+const makeCanvas = (w = 800, h = 600) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  return canvas;
+};
+
+const makeNode = (overrides: Partial<DiagramNode> = {}): DiagramNode => ({
+  id: 'n1', label: 'A', type: 'node', shape: 'roundRect',
+  color: '#fff', stroke: '#333',
+  x: 100, y: 100, width: 80, height: 40,
+  ...overrides,
+});
+
+// ── canvasToWorld ─────────────────────────────────────────────────────────────
+
+describe('useCanvasTransform – canvasToWorld', () => {
+  it('maps canvas coords 1:1 at identity transform', () => {
+    const canvas = makeCanvas();
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    const pos = result.current.canvasToWorld(100, 200);
+    expect(pos).toEqual({ x: 100, y: 200 });
+  });
+
+  it('applies scale and translation correctly', () => {
+    const canvas = makeCanvas();
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    act(() => { result.current.transformRef.current = { x: 50, y: 30, scale: 2 }; });
+    // wx = (150 - 50) / 2 = 50, wy = (230 - 30) / 2 = 100
+    const pos = result.current.canvasToWorld(150, 230);
+    expect(pos.x).toBeCloseTo(50);
+    expect(pos.y).toBeCloseTo(100);
+  });
+
+  it('applies viewBoxOffset stored on canvas element', () => {
+    const canvas = makeCanvas();
+    (canvas as any).viewBoxOffset = { x: -20, y: -10 };
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    // wx = (100 - 0) / 1 - (-20) = 120, wy = (200 - 0) / 1 - (-10) = 210
+    const pos = result.current.canvasToWorld(100, 200);
+    expect(pos.x).toBeCloseTo(120);
+    expect(pos.y).toBeCloseTo(210);
+  });
+});
+
+// ── zoom in / out ─────────────────────────────────────────────────────────────
+
+describe('useCanvasTransform – handleZoomIn', () => {
+  let canvas: HTMLCanvasElement;
+  beforeEach(() => { canvas = makeCanvas(800, 600); });
+
+  it('increases scale by ×1.25', () => {
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    act(() => { result.current.handleZoomIn(); });
+    expect(result.current.transformState.scale).toBeCloseTo(1.25);
+  });
+
+  it('zooms toward the canvas centre', () => {
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    act(() => { result.current.handleZoomIn(); });
+    // cx=400, cy=300; newX = 400 - 400*(1.25/1) = -100
+    expect(result.current.transformState.x).toBeCloseTo(-100);
+    expect(result.current.transformState.y).toBeCloseTo(-75);
+  });
+
+  it('caps scale at 8', () => {
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    act(() => { result.current.transformRef.current = { x: 0, y: 0, scale: 8 }; });
+    act(() => { result.current.handleZoomIn(); });
+    expect(result.current.transformState.scale).toBe(8);
+  });
+});
+
+describe('useCanvasTransform – handleZoomOut', () => {
+  let canvas: HTMLCanvasElement;
+  beforeEach(() => { canvas = makeCanvas(800, 600); });
+
+  it('decreases scale by ×0.8', () => {
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    act(() => { result.current.handleZoomOut(); });
+    expect(result.current.transformState.scale).toBeCloseTo(0.8);
+  });
+
+  it('zooms toward the canvas centre', () => {
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    act(() => { result.current.handleZoomOut(); });
+    // cx=400, cy=300; newX = 400 - 400*(0.8/1) = 80
+    expect(result.current.transformState.x).toBeCloseTo(80);
+    expect(result.current.transformState.y).toBeCloseTo(60);
+  });
+
+  it('floors scale at 0.1', () => {
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    act(() => { result.current.transformRef.current = { x: 0, y: 0, scale: 0.1 }; });
+    act(() => { result.current.handleZoomOut(); });
+    expect(result.current.transformState.scale).toBeCloseTo(0.1);
+  });
+});
+
+// ── wheel zoom ────────────────────────────────────────────────────────────────
+
+describe('useCanvasTransform – handleWheel', () => {
+  it('zooms out when deltaY > 0 (scroll down)', () => {
+    const canvas = makeCanvas(800, 600);
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    const e = new WheelEvent('wheel', { deltaY: 100, clientX: 100, clientY: 100, cancelable: true });
+    act(() => { result.current.handleWheel(e); });
+    // delta=0.9; newScale = min(max(1*0.9,0.1),8) = 0.9
+    expect(result.current.transformState.scale).toBeCloseTo(0.9);
+  });
+
+  it('zooms in when deltaY < 0 (scroll up)', () => {
+    const canvas = makeCanvas(800, 600);
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    const e = new WheelEvent('wheel', { deltaY: -100, clientX: 100, clientY: 100, cancelable: true });
+    act(() => { result.current.handleWheel(e); });
+    // delta=1.1; newScale = 1.1
+    expect(result.current.transformState.scale).toBeCloseTo(1.1);
+  });
+
+  it('zooms around the mouse position', () => {
+    const canvas = makeCanvas(800, 600);
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    // mouseX=100, mouseY=100, delta=0.9, initial x=0,y=0,scale=1
+    // newX = 100 - (100-0)*(0.9/1) = 10
+    const e = new WheelEvent('wheel', { deltaY: 100, clientX: 100, clientY: 100, cancelable: true });
+    act(() => { result.current.handleWheel(e); });
+    expect(result.current.transformState.x).toBeCloseTo(10);
+    expect(result.current.transformState.y).toBeCloseTo(10);
+  });
+
+  it('clamps wheel scale within [0.1, 8]', () => {
+    const canvas = makeCanvas();
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    act(() => { result.current.transformRef.current = { x: 0, y: 0, scale: 0.1 }; });
+    // Scroll down = zoom out, but already at floor
+    const e = new WheelEvent('wheel', { deltaY: 100, clientX: 0, clientY: 0, cancelable: true });
+    act(() => { result.current.handleWheel(e); });
+    expect(result.current.transformState.scale).toBeGreaterThanOrEqual(0.1);
+  });
+});
+
+// ── pan ───────────────────────────────────────────────────────────────────────
+
+describe('useCanvasTransform – pan (mouseDown / mouseMove / mouseUp)', () => {
+  it('panning with mouseDown then mouseMove updates transform', () => {
+    const canvas = makeCanvas();
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    // mouseDown at (200, 150): panStart = { x: 200-0, y: 150-0 } = { x: 200, y: 150 }
+    act(() => { result.current.handleMouseDown({ button: 0, clientX: 200, clientY: 150 } as any); });
+    // mouseMove to (220, 170): newX = 220-200=20, newY=170-150=20
+    act(() => { result.current.handleMouseMove({ clientX: 220, clientY: 170 } as any, [], { current: null }); });
+    expect(result.current.transformState.x).toBe(20);
+    expect(result.current.transformState.y).toBe(20);
+  });
+
+  it('ignores right-click mouseDown (button !== 0)', () => {
+    const canvas = makeCanvas();
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    act(() => { result.current.handleMouseDown({ button: 2, clientX: 200, clientY: 150 } as any); });
+    // Not panning → mouseMove should not update transform
+    act(() => { result.current.handleMouseMove({ clientX: 300, clientY: 250 } as any, [], { current: null }); });
+    expect(result.current.transformState.x).toBe(0);
+    expect(result.current.transformState.y).toBe(0);
+  });
+
+  it('mouseUp stops panning', () => {
+    const canvas = makeCanvas();
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    act(() => { result.current.handleMouseDown({ button: 0, clientX: 200, clientY: 150 } as any); });
+    act(() => { result.current.handleMouseUp(); });
+    // Move after up → transform should not change
+    act(() => { result.current.handleMouseMove({ clientX: 300, clientY: 250 } as any, [], { current: null }); });
+    expect(result.current.transformState.x).toBe(0);
+    expect(result.current.transformState.y).toBe(0);
+  });
+});
+
+// ── hover detection ───────────────────────────────────────────────────────────
+
+describe('useCanvasTransform – handleMouseMove hover detection', () => {
+  // Node at (100,100), width=80, height=40 → hit x∈[60,140], y∈[80,120]
+  // With identity transform and getBoundingClientRect()=all zeros: mouseWorld = clientXY
+
+  it('sets hoveredNodeIdRef when mouse is inside a node', () => {
+    const canvas = makeCanvas();
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    const hoveredRef = { current: null as string | null };
+    const node = makeNode();
+    act(() => { result.current.handleMouseMove({ clientX: 100, clientY: 100 } as any, [node], hoveredRef); });
+    expect(hoveredRef.current).toBe('n1');
+  });
+
+  it('clears hoveredNodeIdRef when mouse is outside all nodes', () => {
+    const canvas = makeCanvas();
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    const hoveredRef = { current: 'n1' as string | null };
+    const node = makeNode();
+    act(() => { result.current.handleMouseMove({ clientX: 500, clientY: 500 } as any, [node], hoveredRef); });
+    expect(hoveredRef.current).toBeNull();
+  });
+
+  it('picks the first matching node', () => {
+    const canvas = makeCanvas();
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    const hoveredRef = { current: null as string | null };
+    const nodeA = makeNode({ id: 'A', x: 100, y: 100 });
+    const nodeB = makeNode({ id: 'B', x: 300, y: 300 });
+    act(() => { result.current.handleMouseMove({ clientX: 100, clientY: 100 } as any, [nodeA, nodeB], hoveredRef); });
+    expect(hoveredRef.current).toBe('A');
+  });
+});
+
+// ── handleMouseLeave ──────────────────────────────────────────────────────────
+
+describe('useCanvasTransform – handleMouseLeave', () => {
+  it('clears hoveredNodeIdRef', () => {
+    const canvas = makeCanvas();
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    const hoveredRef = { current: 'n1' as string | null };
+    act(() => { result.current.handleMouseLeave(hoveredRef); });
+    expect(hoveredRef.current).toBeNull();
+  });
+
+  it('stops panning', () => {
+    const canvas = makeCanvas();
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    act(() => { result.current.handleMouseDown({ button: 0, clientX: 200, clientY: 150 } as any); });
+    act(() => { result.current.handleMouseLeave({ current: null }); });
+    // After leave, mousemove should not update transform
+    act(() => { result.current.handleMouseMove({ clientX: 300, clientY: 250 } as any, [], { current: null }); });
+    expect(result.current.transformState.x).toBe(0);
+  });
+});
+
+// ── fitToScreen ───────────────────────────────────────────────────────────────
+
+describe('useCanvasTransform – fitToScreen', () => {
+  it('does nothing when diagramSize is zero', () => {
+    const canvas = makeCanvas();
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    act(() => { result.current.fitToScreen(); });
+    // diagramSizeRef is { w:0, h:0 } by default → early return, transform unchanged
+    expect(result.current.transformState.scale).toBe(1);
+  });
+
+  it('computes scale to fit diagram into canvas', () => {
+    const canvas = makeCanvas(800, 600);
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    act(() => { result.current.diagramSizeRef.current = { w: 400, h: 300 }; });
+    act(() => { result.current.fitToScreen(); });
+    // scaleX=(800-48)/400=1.88, scaleY=(600-48)/300=1.84 → fitScale=1.84
+    expect(result.current.transformState.scale).toBeCloseTo(1.84, 1);
+  });
+
+  it('centres the diagram horizontally and vertically', () => {
+    const canvas = makeCanvas(800, 600);
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    act(() => { result.current.diagramSizeRef.current = { w: 400, h: 300 }; });
+    act(() => { result.current.fitToScreen(); });
+    // fitX=(800-400*1.84)/2=32, fitY=(600-300*1.84)/2=24
+    expect(result.current.transformState.x).toBeCloseTo(32, 0);
+    expect(result.current.transformState.y).toBeCloseTo(24, 0);
+  });
+
+  it('caps scale at 2 even when diagram is tiny', () => {
+    const canvas = makeCanvas(800, 600);
+    const { result } = renderHook(() => useCanvasTransform({ current: canvas }));
+    act(() => { result.current.diagramSizeRef.current = { w: 50, h: 50 }; });
+    act(() => { result.current.fitToScreen(); });
+    expect(result.current.transformState.scale).toBeLessThanOrEqual(2);
+  });
+});

--- a/src/test/hooks/useEditorResize.test.ts
+++ b/src/test/hooks/useEditorResize.test.ts
@@ -1,0 +1,105 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { useEditorResize } from '../../hooks/useEditorResize';
+
+// Fire mouseup after each test to clean up window event listeners
+afterEach(() => {
+  act(() => { window.dispatchEvent(new MouseEvent('mouseup')); });
+});
+
+// ── initial state ─────────────────────────────────────────────────────────────
+
+describe('useEditorResize – initial state', () => {
+  it('defaults to width 320', () => {
+    const { result } = renderHook(() => useEditorResize());
+    expect(result.current.editorWidth).toBe(320);
+  });
+
+  it('accepts custom initial width', () => {
+    const { result } = renderHook(() => useEditorResize(400));
+    expect(result.current.editorWidth).toBe(400);
+  });
+
+  it('isResizingRef starts as false', () => {
+    const { result } = renderHook(() => useEditorResize());
+    expect(result.current.isResizingRef.current).toBe(false);
+  });
+});
+
+// ── handleResizeStart ─────────────────────────────────────────────────────────
+
+describe('useEditorResize – handleResizeStart', () => {
+  it('calls preventDefault', () => {
+    const { result } = renderHook(() => useEditorResize());
+    const preventDefault = vi.fn();
+    act(() => { result.current.handleResizeStart({ preventDefault, clientX: 300 } as any); });
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it('sets isResizingRef to true', () => {
+    const { result } = renderHook(() => useEditorResize());
+    act(() => { result.current.handleResizeStart({ preventDefault: vi.fn(), clientX: 300 } as any); });
+    expect(result.current.isResizingRef.current).toBe(true);
+  });
+
+  it('sets body cursor to col-resize', () => {
+    const { result } = renderHook(() => useEditorResize());
+    act(() => { result.current.handleResizeStart({ preventDefault: vi.fn(), clientX: 300 } as any); });
+    expect(document.body.style.cursor).toBe('col-resize');
+  });
+});
+
+// ── mousemove during resize ───────────────────────────────────────────────────
+
+describe('useEditorResize – mousemove', () => {
+  it('updates editorWidth by the drag delta', () => {
+    // start at 320, drag start at x=300, move to x=350 → delta=+50 → 320+50=370
+    const { result } = renderHook(() => useEditorResize(320));
+    act(() => { result.current.handleResizeStart({ preventDefault: vi.fn(), clientX: 300 } as any); });
+    act(() => { window.dispatchEvent(new MouseEvent('mousemove', { clientX: 350 })); });
+    expect(result.current.editorWidth).toBe(370);
+  });
+
+  it('clamps width to minimum 180', () => {
+    // 320 + (0 - 300) = 20, clamped to 180
+    const { result } = renderHook(() => useEditorResize(320));
+    act(() => { result.current.handleResizeStart({ preventDefault: vi.fn(), clientX: 300 } as any); });
+    act(() => { window.dispatchEvent(new MouseEvent('mousemove', { clientX: 0 })); });
+    expect(result.current.editorWidth).toBe(180);
+  });
+
+  it('clamps width to maximum 600', () => {
+    // 320 + (900 - 300) = 920, clamped to 600
+    const { result } = renderHook(() => useEditorResize(320));
+    act(() => { result.current.handleResizeStart({ preventDefault: vi.fn(), clientX: 300 } as any); });
+    act(() => { window.dispatchEvent(new MouseEvent('mousemove', { clientX: 900 })); });
+    expect(result.current.editorWidth).toBe(600);
+  });
+});
+
+// ── mouseup ───────────────────────────────────────────────────────────────────
+
+describe('useEditorResize – mouseup', () => {
+  it('sets isResizingRef to false', () => {
+    const { result } = renderHook(() => useEditorResize());
+    act(() => { result.current.handleResizeStart({ preventDefault: vi.fn(), clientX: 300 } as any); });
+    act(() => { window.dispatchEvent(new MouseEvent('mouseup')); });
+    expect(result.current.isResizingRef.current).toBe(false);
+  });
+
+  it('resets body cursor', () => {
+    const { result } = renderHook(() => useEditorResize());
+    act(() => { result.current.handleResizeStart({ preventDefault: vi.fn(), clientX: 300 } as any); });
+    act(() => { window.dispatchEvent(new MouseEvent('mouseup')); });
+    expect(document.body.style.cursor).toBe('');
+  });
+
+  it('stops updating width after mouseup', () => {
+    const { result } = renderHook(() => useEditorResize(320));
+    act(() => { result.current.handleResizeStart({ preventDefault: vi.fn(), clientX: 300 } as any); });
+    act(() => { window.dispatchEvent(new MouseEvent('mouseup')); });
+    const widthAfterUp = result.current.editorWidth;
+    act(() => { window.dispatchEvent(new MouseEvent('mousemove', { clientX: 900 })); });
+    expect(result.current.editorWidth).toBe(widthAfterUp);
+  });
+});

--- a/src/test/hooks/useParticleSystem.test.ts
+++ b/src/test/hooks/useParticleSystem.test.ts
@@ -1,0 +1,117 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useParticleSystem } from '../../hooks/useParticleSystem';
+import type { DiagramEdge } from '../../types';
+
+const linkEdge = (overrides: Partial<DiagramEdge> = {}): DiagramEdge => ({
+  id: 'e1',
+  pathD: 'M 0 0 L 100 100',
+  stroke: '#333',
+  type: 'link',
+  ...overrides,
+});
+
+// ── initial state ─────────────────────────────────────────────────────────────
+
+describe('useParticleSystem – initial state', () => {
+  it('returns empty array when no edges', () => {
+    const edges: DiagramEdge[] = [];
+    const { result } = renderHook(() => useParticleSystem(edges));
+    expect(result.current).toHaveLength(0);
+  });
+
+  it('skips structural edges', () => {
+    const edges = [linkEdge({ type: 'structural' })];
+    const { result } = renderHook(() => useParticleSystem(edges));
+    expect(result.current).toHaveLength(0);
+  });
+
+  it('creates at least 2 particles per link edge', () => {
+    const edges = [linkEdge()];
+    const { result } = renderHook(() => useParticleSystem(edges));
+    expect(result.current.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ── particle count ────────────────────────────────────────────────────────────
+
+describe('useParticleSystem – particle count', () => {
+  it('creates more particles for longer pathD', () => {
+    // short: 11 chars → floor(11/150)=0 → max(1,0)+1=2
+    const shortEdges = [linkEdge({ pathD: 'M 0 0 L 1 0' })];
+    // long: 326 chars → floor(326/150)=2 → max(1,2)+1=3
+    const longEdges = [linkEdge({ pathD: 'M 0 0 ' + 'L 100 0 '.repeat(40) })];
+    const { result: short } = renderHook(() => useParticleSystem(shortEdges));
+    const { result: long } = renderHook(() => useParticleSystem(longEdges));
+    expect(long.current.length).toBeGreaterThan(short.current.length);
+  });
+
+  it('accumulates particles across multiple link edges', () => {
+    const single = [linkEdge()];
+    const double = [linkEdge({ id: 'e1' }), linkEdge({ id: 'e2' })];
+    const { result: singleResult } = renderHook(() => useParticleSystem(single));
+    const { result: doubleResult } = renderHook(() => useParticleSystem(double));
+    expect(doubleResult.current.length).toBeGreaterThan(singleResult.current.length);
+  });
+
+  it('ignores structural edges when mixed with link edges', () => {
+    const linkOnly = [linkEdge({ id: 'e1' })];
+    const mixed = [linkEdge({ id: 'e1' }), linkEdge({ id: 'e2', type: 'structural' })];
+    const { result: linkResult } = renderHook(() => useParticleSystem(linkOnly));
+    const { result: mixedResult } = renderHook(() => useParticleSystem(mixed));
+    expect(mixedResult.current.length).toBe(linkResult.current.length);
+  });
+});
+
+// ── sankey edges ──────────────────────────────────────────────────────────────
+
+describe('useParticleSystem – Sankey particle count', () => {
+  it('uses lineWidth formula for sankey edges', () => {
+    // lineWidth=100: floor(100/20)=5, min(5,12)=5, max(2,5)=5
+    const edges = [linkEdge({ sankeyFillPath: 'M 0 0 L 100 0', lineWidth: 100 })];
+    const { result } = renderHook(() => useParticleSystem(edges));
+    expect(result.current.length).toBe(5);
+  });
+
+  it('caps sankey particles at 12', () => {
+    // lineWidth=400: floor(400/20)=20, min(20,12)=12, max(2,12)=12
+    const edges = [linkEdge({ sankeyFillPath: 'M 0 0 L 100 0', lineWidth: 400 })];
+    const { result } = renderHook(() => useParticleSystem(edges));
+    expect(result.current.length).toBe(12);
+  });
+
+  it('sankey with small lineWidth produces minimum 2 particles', () => {
+    // lineWidth=4: floor(4/20)=0, min(0,12)=0, max(2,0)=2
+    const edges = [linkEdge({ sankeyFillPath: 'M 0 0 L 100 0', lineWidth: 4 })];
+    const { result } = renderHook(() => useParticleSystem(edges));
+    expect(result.current.length).toBe(2);
+  });
+});
+
+// ── reactivity ────────────────────────────────────────────────────────────────
+
+describe('useParticleSystem – reactivity', () => {
+  it('replaces particles when edges are removed', () => {
+    const initial = [linkEdge()];
+    const { result, rerender } = renderHook(
+      ({ edges }) => useParticleSystem(edges),
+      { initialProps: { edges: initial } }
+    );
+    expect(result.current.length).toBeGreaterThan(0);
+    const empty: DiagramEdge[] = [];
+    rerender({ edges: empty });
+    expect(result.current.length).toBe(0);
+  });
+
+  it('creates new particles when edges are added', () => {
+    const empty: DiagramEdge[] = [];
+    const { result, rerender } = renderHook(
+      ({ edges }) => useParticleSystem(edges),
+      { initialProps: { edges: empty } }
+    );
+    expect(result.current.length).toBe(0);
+    const withEdge = [linkEdge()];
+    rerender({ edges: withEdge });
+    expect(result.current.length).toBeGreaterThan(0);
+  });
+});

--- a/src/test/renderers/canvasRenderer.drawGrid.test.ts
+++ b/src/test/renderers/canvasRenderer.drawGrid.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { drawGrid } from '../../utils/canvasRenderer';
+
+const makeCtx = () => ({
+  strokeStyle: '' as string | CanvasGradient | CanvasPattern,
+  lineWidth: 1,
+  beginPath: vi.fn(),
+  moveTo: vi.fn(),
+  lineTo: vi.fn(),
+  stroke: vi.fn(),
+}) as unknown as CanvasRenderingContext2D;
+
+describe('drawGrid', () => {
+  it('calls stroke() to render lines', () => {
+    const ctx = makeCtx();
+    drawGrid(ctx, 800, 600);
+    expect(ctx.stroke).toHaveBeenCalled();
+  });
+
+  it('sets strokeStyle to low-opacity dark color', () => {
+    const ctx = makeCtx();
+    drawGrid(ctx, 800, 600);
+    expect(ctx.strokeStyle).toBe('rgba(0,0,0,0.05)');
+  });
+
+  it('sets lineWidth to 1', () => {
+    const ctx = makeCtx();
+    drawGrid(ctx, 800, 600);
+    expect(ctx.lineWidth).toBe(1);
+  });
+
+  it('calls moveTo and lineTo to build line paths', () => {
+    const ctx = makeCtx();
+    drawGrid(ctx, 800, 600);
+    expect(ctx.moveTo).toHaveBeenCalled();
+    expect(ctx.lineTo).toHaveBeenCalled();
+  });
+
+  it('draws more lines for a larger canvas', () => {
+    const ctxSmall = makeCtx();
+    const ctxLarge = makeCtx();
+    drawGrid(ctxSmall, 100, 100);
+    drawGrid(ctxLarge, 1000, 1000);
+    const small = (ctxSmall.moveTo as ReturnType<typeof vi.fn>).mock.calls.length;
+    const large = (ctxLarge.moveTo as ReturnType<typeof vi.fn>).mock.calls.length;
+    expect(large).toBeGreaterThan(small);
+  });
+
+  it('does not throw for zero-size canvas', () => {
+    const ctx = makeCtx();
+    expect(() => drawGrid(ctx, 0, 0)).not.toThrow();
+  });
+});

--- a/src/test/renderers/canvasRenderer.drawNode.test.ts
+++ b/src/test/renderers/canvasRenderer.drawNode.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi } from 'vitest';
+import { drawNode } from '../../utils/canvasRenderer';
+import type { DiagramNode } from '../../types';
+
+const makeCtx = () => {
+  const ctx = {
+    shadowColor: '',
+    shadowBlur: 0,
+    shadowOffsetY: 0,
+    fillStyle: '' as string | CanvasGradient | CanvasPattern,
+    strokeStyle: '' as string | CanvasGradient | CanvasPattern,
+    lineWidth: 1,
+    font: '',
+    textAlign: 'center' as CanvasTextAlign,
+    textBaseline: 'middle' as CanvasTextBaseline,
+    globalAlpha: 1,
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    arcTo: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    rect: vi.fn(),
+    roundRect: vi.fn(),
+    ellipse: vi.fn(),
+    closePath: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    translate: vi.fn(),
+    clip: vi.fn(),
+    setLineDash: vi.fn(),
+    measureText: vi.fn((text: string) => ({ width: text.length * 8 })),
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+};
+
+const baseNode = (overrides: Partial<DiagramNode> = {}): DiagramNode => ({
+  id: 'n1',
+  label: 'Test',
+  type: 'node',
+  shape: 'roundRect',
+  color: '#ffffff',
+  stroke: '#334155',
+  x: 100,
+  y: 100,
+  width: 120,
+  height: 60,
+  ...overrides,
+});
+
+// ── smoke tests: every shape renders without throwing ─────────────────────────
+
+describe('drawNode – shape smoke tests', () => {
+  const shapes: DiagramNode['shape'][] = [
+    'roundRect', 'rect', 'circle', 'stadium', 'subroutine',
+    'diamond', 'hexagon', 'note', 'forkJoin',
+    'parallelogram', 'parallelogramAlt', 'trapezoid', 'trapezoidAlt', 'asymmetric',
+    'endCircle', 'mergeCircle', 'reverseCircle', 'highlightRect',
+    'cylinder', 'cloud', 'bang', 'actorMan', 'c4Person',
+  ];
+
+  for (const shape of shapes) {
+    it(`does not throw for shape "${shape}"`, () => {
+      const ctx = makeCtx();
+      expect(() => drawNode(ctx, baseNode({ shape }), false, null, '#6366f1')).not.toThrow();
+    });
+  }
+
+  it('does not throw for shape "pie" with pieWedge', () => {
+    const ctx = makeCtx();
+    const node = baseNode({
+      shape: 'pie',
+      pieWedge: { cx: 100, cy: 100, radius: 50, startAngle: 0, endAngle: Math.PI },
+    });
+    expect(() => drawNode(ctx, node, false, null, '#6366f1')).not.toThrow();
+  });
+
+  it('does not throw for shape "pie" without pieWedge (no-op)', () => {
+    const ctx = makeCtx();
+    expect(() => drawNode(ctx, baseNode({ shape: 'pie' }), false, null, '#6366f1')).not.toThrow();
+  });
+});
+
+// ── shadow: hovered vs premium vs normal ─────────────────────────────────────
+
+describe('drawNode – shadow state', () => {
+  it('applies particle-color shadow when node is hovered', () => {
+    const ctx = makeCtx();
+    let shadowDuringDraw = '';
+    (ctx.fill as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      shadowDuringDraw = ctx.shadowColor;
+    });
+    drawNode(ctx, baseNode({ id: 'n1' }), false, 'n1', '#6366f1');
+    expect(shadowDuringDraw).toBe('#6366f1');
+  });
+
+  it('resets shadowBlur to 0 after drawing', () => {
+    const ctx = makeCtx();
+    drawNode(ctx, baseNode(), false, null, '#6366f1');
+    expect(ctx.shadowBlur).toBe(0);
+  });
+});
+
+// ── stroke color: hovered node ────────────────────────────────────────────────
+
+describe('drawNode – hovered stroke', () => {
+  it('uses particleColor as strokeStyle when hovered (roundRect)', () => {
+    const ctx = makeCtx();
+    drawNode(ctx, baseNode({ id: 'target' }), false, 'target', '#ff0000');
+    expect(ctx.strokeStyle).toBe('#ff0000');
+  });
+
+  it('uses node.stroke when not hovered', () => {
+    const ctx = makeCtx();
+    drawNode(ctx, baseNode({ stroke: '#abc123' }), false, null, '#ff0000');
+    expect(ctx.strokeStyle).toBe('#abc123');
+  });
+});
+
+// ── cluster nodes ─────────────────────────────────────────────────────────────
+
+describe('drawNode – cluster nodes', () => {
+  it('renders dashed cluster (flowchart subgraph) without throwing', () => {
+    const ctx = makeCtx();
+    const node = baseNode({ type: 'cluster', shape: 'rect', label: 'Group' });
+    expect(() => drawNode(ctx, node, false, null, '#6366f1')).not.toThrow();
+  });
+
+  it('renders roundRect cluster with label without throwing', () => {
+    const ctx = makeCtx();
+    const node = baseNode({ type: 'cluster', shape: 'roundRect', label: 'State' });
+    expect(() => drawNode(ctx, node, false, null, '#6366f1')).not.toThrow();
+  });
+
+  it('renders roundRect cluster with empty label (concurrent region) without throwing', () => {
+    const ctx = makeCtx();
+    const node = baseNode({ type: 'cluster', shape: 'roundRect', label: '' });
+    expect(() => drawNode(ctx, node, false, null, '#6366f1')).not.toThrow();
+  });
+});
+
+// ── special nodeKind ──────────────────────────────────────────────────────────
+
+describe('drawNode – nodeKind', () => {
+  it('renders stepNum node without throwing', () => {
+    const ctx = makeCtx();
+    const node = baseNode({ nodeKind: 'stepNum', label: '1', shape: 'circle', width: 24, height: 24 });
+    expect(() => drawNode(ctx, node, false, null, '#6366f1')).not.toThrow();
+  });
+
+  it('renders activation node without throwing', () => {
+    const ctx = makeCtx();
+    const node = baseNode({ nodeKind: 'activation', shape: 'rect' });
+    expect(() => drawNode(ctx, node, false, null, '#6366f1')).not.toThrow();
+  });
+});
+
+// ── classLines nodes ──────────────────────────────────────────────────────────
+
+describe('drawNode – classLines', () => {
+  it('renders a node with classLines without throwing', () => {
+    const ctx = makeCtx();
+    const node = baseNode({
+      classLines: [
+        { text: 'MyClass', bold: true },
+        { divider: true },
+        { text: '+ name: String' },
+      ],
+    });
+    expect(() => drawNode(ctx, node, false, null, '#6366f1')).not.toThrow();
+  });
+});
+
+// ── multi-line labels ─────────────────────────────────────────────────────────
+
+describe('drawNode – multi-line labels', () => {
+  it('renders multi-line label without throwing', () => {
+    const ctx = makeCtx();
+    const node = baseNode({ label: 'Line one\nLine two\nLine three' });
+    expect(() => drawNode(ctx, node, false, null, '#6366f1')).not.toThrow();
+  });
+
+  it('renders bold-marked label (**text**) without throwing', () => {
+    const ctx = makeCtx();
+    const node = baseNode({ label: '**Important**' });
+    expect(() => drawNode(ctx, node, false, null, '#6366f1')).not.toThrow();
+  });
+});
+
+// ── dark background ───────────────────────────────────────────────────────────
+
+describe('drawNode – dark background', () => {
+  it('renders dark-bg node without throwing', () => {
+    const ctx = makeCtx();
+    const node = baseNode({ color: '#0f172a' });
+    expect(() => drawNode(ctx, node, false, null, '#6366f1')).not.toThrow();
+  });
+});

--- a/src/test/renderers/drawEdge.borderPoint.shapes.test.ts
+++ b/src/test/renderers/drawEdge.borderPoint.shapes.test.ts
@@ -1,0 +1,161 @@
+/**
+ * borderPoint coverage for shapes not covered by drawEdge.borderPoint.test.ts:
+ * - ellipse branch: circle, cloud, bang
+ * - L1-norm branch: diamond
+ * - rect fallback: roundRect, stadium, note, hexagon, subroutine, cylinder
+ */
+import { describe, it, expect } from 'vitest';
+import { borderPoint } from '../../utils/drawEdge';
+import type { DiagramNode } from '../../types';
+
+const node = (
+  shape: DiagramNode['shape'],
+  cx = 0, cy = 0,
+  width = 100, height = 40,
+): DiagramNode => ({
+  id: 'n', label: '', type: 'node',
+  x: cx, y: cy, width, height,
+  color: '#fff', stroke: '#333', shape,
+});
+
+const approx = (a: number, b: number, tol = 0.5) => Math.abs(a - b) < tol;
+
+// ── ellipse branch: circle ────────────────────────────────────────────────────
+
+describe('borderPoint – circle (ellipse formula)', () => {
+  const n = node('circle', 0, 0, 100, 100); // rx = ry = 50
+
+  it('angle=0 (right): x = +50, y ≈ 0', () => {
+    const pt = borderPoint(0, n);
+    expect(approx(pt.x, 50)).toBe(true);
+    expect(approx(pt.y, 0)).toBe(true);
+  });
+
+  it('angle=π (left): x = -50, y ≈ 0', () => {
+    const pt = borderPoint(Math.PI, n);
+    expect(approx(pt.x, -50)).toBe(true);
+    expect(approx(pt.y, 0)).toBe(true);
+  });
+
+  it('angle=-π/2 (up): y = -50', () => {
+    const pt = borderPoint(-Math.PI / 2, n);
+    expect(approx(pt.y, -50)).toBe(true);
+    expect(approx(pt.x, 0)).toBe(true);
+  });
+
+  it('angle=π/2 (down): y = +50', () => {
+    const pt = borderPoint(Math.PI / 2, n);
+    expect(approx(pt.y, 50)).toBe(true);
+    expect(approx(pt.x, 0)).toBe(true);
+  });
+
+  it('point lies on the ellipse surface', () => {
+    for (const angle of [0.1, 0.7, 1.3, 2.0, 2.8, 4.0, 5.5]) {
+      const { x, y } = borderPoint(angle, n);
+      const hw = 50, hh = 50;
+      // (x/hw)^2 + (y/hh)^2 ≈ 1
+      expect((x / hw) ** 2 + (y / hh) ** 2).toBeCloseTo(1, 1);
+    }
+  });
+});
+
+// ── ellipse branch: cloud / bang ──────────────────────────────────────────────
+
+describe('borderPoint – cloud (ellipse formula)', () => {
+  const n = node('cloud', 0, 0, 120, 60); // hw=60, hh=30
+
+  it('angle=0: x = +60', () => {
+    const pt = borderPoint(0, n);
+    expect(approx(pt.x, 60)).toBe(true);
+  });
+
+  it('angle=π/2: y = +30', () => {
+    const pt = borderPoint(Math.PI / 2, n);
+    expect(approx(pt.y, 30)).toBe(true);
+  });
+
+  it('non-axis angle: lies on ellipse', () => {
+    const angle = Math.PI / 4;
+    const { x, y } = borderPoint(angle, n);
+    expect((x / 60) ** 2 + (y / 30) ** 2).toBeCloseTo(1, 1);
+  });
+});
+
+describe('borderPoint – bang (ellipse formula)', () => {
+  const n = node('bang', 0, 0, 80, 80); // hw=hh=40
+
+  it('angle=0: x = +40', () => {
+    const pt = borderPoint(0, n);
+    expect(approx(pt.x, 40)).toBe(true);
+  });
+
+  it('angle=π: x = -40', () => {
+    const pt = borderPoint(Math.PI, n);
+    expect(approx(pt.x, -40)).toBe(true);
+  });
+});
+
+// ── L1-norm branch: diamond ───────────────────────────────────────────────────
+
+describe('borderPoint – diamond (L1-norm formula)', () => {
+  // width=100, height=40 → hw=50, hh=20
+  const n = node('diamond');
+
+  it('angle=0 (right): x = hw = +50', () => {
+    const pt = borderPoint(0, n);
+    expect(approx(pt.x, 50)).toBe(true);
+    expect(approx(pt.y, 0)).toBe(true);
+  });
+
+  it('angle=π (left): x = -hw = -50', () => {
+    const pt = borderPoint(Math.PI, n);
+    expect(approx(pt.x, -50)).toBe(true);
+    expect(approx(pt.y, 0)).toBe(true);
+  });
+
+  it('angle=-π/2 (up): y = -hh = -20', () => {
+    const pt = borderPoint(-Math.PI / 2, n);
+    expect(approx(pt.y, -20)).toBe(true);
+    expect(approx(pt.x, 0)).toBe(true);
+  });
+
+  it('angle=π/2 (down): y = +hh = +20', () => {
+    const pt = borderPoint(Math.PI / 2, n);
+    expect(approx(pt.y, 20)).toBe(true);
+    expect(approx(pt.x, 0)).toBe(true);
+  });
+
+  it('45° diagonal: point lies on diamond edge (|x|/hw + |y|/hh = 1)', () => {
+    const pt = borderPoint(Math.PI / 4, n);
+    const hw = 50, hh = 20;
+    expect(Math.abs(pt.x) / hw + Math.abs(pt.y) / hh).toBeCloseTo(1, 2);
+  });
+});
+
+// ── rect fallback: various shapes that share the rectangular border ───────────
+
+describe('borderPoint – rect-fallback shapes', () => {
+  // All these shapes fall through to the default rectangle calculation:
+  // t = min(hw / |dx|, hh / |dy|)
+  const rectLike: DiagramNode['shape'][] = [
+    'roundRect', 'stadium', 'note', 'hexagon', 'subroutine', 'cylinder', 'forkJoin',
+  ];
+
+  for (const shape of rectLike) {
+    describe(`shape: ${shape}`, () => {
+      const n = node(shape); // width=100, height=40 → hw=50, hh=20
+
+      it('angle=0 (right): x ≈ +50', () => {
+        const pt = borderPoint(0, n);
+        expect(approx(pt.x, 50)).toBe(true);
+        expect(approx(pt.y, 0)).toBe(true);
+      });
+
+      it('angle=π/2 (down): y ≈ +20', () => {
+        const pt = borderPoint(Math.PI / 2, n);
+        expect(approx(pt.y, 20)).toBe(true);
+        expect(approx(pt.x, 0)).toBe(true);
+      });
+    });
+  }
+});

--- a/src/test/renderers/drawEdge.drawEdge.test.ts
+++ b/src/test/renderers/drawEdge.drawEdge.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { drawEdge } from '../../utils/drawEdge';
+import type { DiagramEdge, DiagramNode } from '../../types';
+
+// Path2D is not implemented in jsdom; stub it so new Path2D(d) succeeds.
+beforeAll(() => {
+  if (typeof Path2D === 'undefined') {
+    vi.stubGlobal('Path2D', class { constructor(_d: string) {} });
+  }
+});
+
+const makeCtx = () => {
+  const fakeGrad = { addColorStop: vi.fn() };
+  const ctx = {
+    strokeStyle: '' as string | CanvasGradient | CanvasPattern,
+    fillStyle: '' as string | CanvasGradient | CanvasPattern,
+    lineWidth: 1,
+    lineCap: 'butt' as CanvasLineCap,
+    globalAlpha: 1,
+    stroke: vi.fn(),
+    fill: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    rect: vi.fn(),
+    clip: vi.fn(),
+    translate: vi.fn(),
+    rotate: vi.fn(),
+    setLineDash: vi.fn(),
+    createLinearGradient: vi.fn(() => fakeGrad),
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+};
+
+const baseEdge = (overrides: Partial<DiagramEdge> = {}): DiagramEdge => ({
+  id: `e-${Math.random()}`,
+  pathD: 'M 10 20 L 90 80',
+  stroke: '#6366f1',
+  type: 'link',
+  ...overrides,
+});
+
+const node = (overrides: Partial<DiagramNode> = {}): DiagramNode => ({
+  id: 'n1', label: 'A', type: 'node', shape: 'roundRect',
+  color: '#fff', stroke: '#333', x: 100, y: 80, width: 120, height: 60,
+  ...overrides,
+});
+
+// ── smoke tests ───────────────────────────────────────────────────────────────
+
+describe('drawEdge – smoke tests', () => {
+  it('renders a plain link edge without throwing', () => {
+    const ctx = makeCtx();
+    expect(() => drawEdge(ctx, baseEdge(), false)).not.toThrow();
+  });
+
+  it('renders a structural edge without throwing', () => {
+    const ctx = makeCtx();
+    expect(() => drawEdge(ctx, baseEdge({ type: 'structural' }), false)).not.toThrow();
+  });
+
+  it('renders an edge with arrowEnd without throwing', () => {
+    const ctx = makeCtx();
+    expect(() => drawEdge(ctx, baseEdge({ arrowEnd: 'default' }), false)).not.toThrow();
+  });
+
+  it('renders an edge with arrowStart without throwing', () => {
+    const ctx = makeCtx();
+    expect(() => drawEdge(ctx, baseEdge({ arrowStart: 'default' }), false)).not.toThrow();
+  });
+
+  it('renders an edge with hasArrow without throwing', () => {
+    const ctx = makeCtx();
+    expect(() => drawEdge(ctx, baseEdge({ hasArrow: true }), false)).not.toThrow();
+  });
+
+  it('calls ctx.stroke() to render the path', () => {
+    const ctx = makeCtx();
+    drawEdge(ctx, baseEdge(), false);
+    expect(ctx.stroke).toHaveBeenCalled();
+  });
+});
+
+// ── edge color resolution ─────────────────────────────────────────────────────
+
+describe('drawEdge – edge color', () => {
+  it('uses explicit stroke when luminance > 0.1 (bright color)', () => {
+    const ctx = makeCtx();
+    drawEdge(ctx, baseEdge({ stroke: '#6366f1' }), false);
+    expect(ctx.strokeStyle).toBe('#6366f1');
+  });
+
+  it('does NOT use stroke when luminance < 0.1 (near-black default)', () => {
+    const ctx = makeCtx();
+    drawEdge(ctx, baseEdge({ stroke: '#333333' }), false);
+    expect(ctx.strokeStyle).not.toBe('#333333');
+  });
+
+  it('non-premium structural edge → gray fallback #9ca3af', () => {
+    const ctx = makeCtx();
+    drawEdge(ctx, baseEdge({ stroke: '#333333', type: 'structural' }), false);
+    expect(ctx.strokeStyle).toBe('#9ca3af');
+  });
+
+  it('premium structural edge → lighter gray #cbd5e1', () => {
+    const ctx = makeCtx();
+    drawEdge(ctx, baseEdge({ stroke: '#333333', type: 'structural' }), true);
+    expect(ctx.strokeStyle).toBe('#cbd5e1');
+  });
+
+  it('link edge with no meaningful stroke → #64748b', () => {
+    const ctx = makeCtx();
+    drawEdge(ctx, baseEdge({ stroke: 'none', type: 'link' }), false);
+    expect(ctx.strokeStyle).toBe('#64748b');
+  });
+});
+
+// ── dash style ────────────────────────────────────────────────────────────────
+
+describe('drawEdge – line dash', () => {
+  it('applies edge.dash when set', () => {
+    const ctx = makeCtx();
+    drawEdge(ctx, baseEdge({ dash: [4, 4] }), false);
+    const calls = (ctx.setLineDash as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.some(([arg]) => JSON.stringify(arg) === JSON.stringify([4, 4]))).toBe(true);
+  });
+
+  it('uses [5,5] for structural edges', () => {
+    const ctx = makeCtx();
+    drawEdge(ctx, baseEdge({ type: 'structural' }), false);
+    const calls = (ctx.setLineDash as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.some(([arg]) => JSON.stringify(arg) === JSON.stringify([5, 5]))).toBe(true);
+  });
+
+  it('uses [] for plain link edges', () => {
+    const ctx = makeCtx();
+    drawEdge(ctx, baseEdge({ type: 'link' }), false);
+    const calls = (ctx.setLineDash as ReturnType<typeof vi.fn>).mock.calls;
+    // First relevant call (before stroke) should be []
+    expect(calls.some(([arg]) => JSON.stringify(arg) === JSON.stringify([]))).toBe(true);
+  });
+});
+
+// ── Sankey edges ──────────────────────────────────────────────────────────────
+
+describe('drawEdge – Sankey', () => {
+  it('renders Sankey edge without throwing', () => {
+    const ctx = makeCtx();
+    const edge = baseEdge({ sankeyFillPath: 'M 0 0 C 50 0 50 100 100 100' });
+    expect(() => drawEdge(ctx, edge, false)).not.toThrow();
+  });
+
+  it('sets globalAlpha to 0.5 during Sankey draw', () => {
+    const ctx = makeCtx();
+    let alphaDuringDraw = 1;
+    (ctx.stroke as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      alphaDuringDraw = ctx.globalAlpha;
+    });
+    const edge = baseEdge({ sankeyFillPath: 'M 0 0 L 100 0' });
+    drawEdge(ctx, edge, false);
+    expect(alphaDuringDraw).toBe(0.5);
+  });
+
+  it('resets globalAlpha to 1 after Sankey draw', () => {
+    const ctx = makeCtx();
+    const edge = baseEdge({ sankeyFillPath: 'M 0 0 L 100 0' });
+    drawEdge(ctx, edge, false);
+    expect(ctx.globalAlpha).toBe(1);
+  });
+
+  it('uses edge.lineWidth when set on Sankey edge', () => {
+    const ctx = makeCtx();
+    const edge = baseEdge({ sankeyFillPath: 'M 0 0 L 100 0', lineWidth: 20 });
+    drawEdge(ctx, edge, false);
+    expect(ctx.lineWidth).toBe(20);
+  });
+
+  it('defaults lineWidth to 4 when not set on Sankey edge', () => {
+    const ctx = makeCtx();
+    const edge = baseEdge({ sankeyFillPath: 'M 0 0 L 100 0' });
+    drawEdge(ctx, edge, false);
+    expect(ctx.lineWidth).toBe(4);
+  });
+
+  it('creates gradient when sankeyGradient is set', () => {
+    const ctx = makeCtx();
+    const edge = baseEdge({
+      sankeyFillPath: 'M 10 20 L 90 80',
+      sankeyGradient: ['#ff0000', '#0000ff'],
+    });
+    drawEdge(ctx, edge, false);
+    expect(ctx.createLinearGradient).toHaveBeenCalled();
+  });
+
+  it('calls save() and restore() for Sankey edge', () => {
+    const ctx = makeCtx();
+    const edge = baseEdge({ sankeyFillPath: 'M 0 0 L 100 0' });
+    drawEdge(ctx, edge, false);
+    expect(ctx.save).toHaveBeenCalled();
+    expect(ctx.restore).toHaveBeenCalled();
+  });
+});
+
+// ── cluster clip ──────────────────────────────────────────────────────────────
+
+describe('drawEdge – cluster clip', () => {
+  it('uses save/clip/restore when toNode is a cluster', () => {
+    const ctx = makeCtx();
+    const cluster = node({ id: 'c1', type: 'cluster' });
+    const edge = baseEdge({ toNodeId: 'c1' });
+    drawEdge(ctx, edge, false, [cluster]);
+    expect(ctx.save).toHaveBeenCalled();
+    expect(ctx.clip).toHaveBeenCalled();
+    expect(ctx.restore).toHaveBeenCalled();
+  });
+
+  it('uses save/clip/restore when fromNode is a cluster', () => {
+    const ctx = makeCtx();
+    const cluster = node({ id: 'c2', type: 'cluster' });
+    const edge = baseEdge({ fromNodeId: 'c2' });
+    drawEdge(ctx, edge, false, [cluster]);
+    expect(ctx.save).toHaveBeenCalled();
+    expect(ctx.clip).toHaveBeenCalled();
+  });
+
+  it('does NOT clip when neither end is a cluster', () => {
+    const ctx = makeCtx();
+    const n = node({ id: 'n1', type: 'node' });
+    const edge = baseEdge({ toNodeId: 'n1' });
+    drawEdge(ctx, edge, false, [n]);
+    expect(ctx.clip).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/renderers/drawParticles.test.ts
+++ b/src/test/renderers/drawParticles.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi } from 'vitest';
+import { drawParticles } from '../../utils/drawParticles';
+import type { ParticleShape } from '../../utils/drawParticles';
+
+const makeCtx = () => {
+  const ctx = {
+    globalCompositeOperation: 'source-over' as GlobalCompositeOperation,
+    shadowBlur: 0,
+    shadowColor: '',
+    fillStyle: '' as string | CanvasGradient | CanvasPattern,
+    beginPath: vi.fn(),
+    rect: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    arc: vi.fn(),
+    bezierCurveTo: vi.fn(),
+    closePath: vi.fn(),
+    fill: vi.fn(),
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+};
+
+const makeParticle = (x: number, y: number) => ({
+  getPosition: () => ({ x, y }),
+});
+
+// ── canvas state ──────────────────────────────────────────────────────────────
+
+describe('drawParticles – canvas state', () => {
+  it('sets globalCompositeOperation to multiply while drawing', () => {
+    const ctx = makeCtx();
+    let opDuringDraw = '';
+    (ctx.fill as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      opDuringDraw = ctx.globalCompositeOperation;
+    });
+    const p = makeParticle(10, 20);
+    drawParticles(ctx, [p as never], '#ff0000', 5, 'circle');
+    expect(opDuringDraw).toBe('multiply');
+  });
+
+  it('resets globalCompositeOperation to source-over after drawing', () => {
+    const ctx = makeCtx();
+    drawParticles(ctx, [makeParticle(10, 20) as never], '#ff0000', 5, 'circle');
+    expect(ctx.globalCompositeOperation).toBe('source-over');
+  });
+
+  it('resets shadowBlur to 0 after drawing', () => {
+    const ctx = makeCtx();
+    drawParticles(ctx, [makeParticle(10, 20) as never], '#ff0000', 5, 'circle');
+    expect(ctx.shadowBlur).toBe(0);
+  });
+
+  it('applies particleColor to fillStyle and shadowColor', () => {
+    const ctx = makeCtx();
+    drawParticles(ctx, [], '#abc123', 5, 'circle');
+    expect(ctx.fillStyle).toBe('#abc123');
+    expect(ctx.shadowColor).toBe('#abc123');
+  });
+
+});
+
+// ── skip (0,0) particles ──────────────────────────────────────────────────────
+
+describe('drawParticles – skip zero-position particles', () => {
+  it('does not call fill() for a particle at (0,0)', () => {
+    const ctx = makeCtx();
+    drawParticles(ctx, [makeParticle(0, 0) as never], '#ff0000', 5, 'circle');
+    expect(ctx.fill).not.toHaveBeenCalled();
+  });
+
+  it('skips (0,0) but still draws other particles', () => {
+    const ctx = makeCtx();
+    const particles = [makeParticle(0, 0), makeParticle(50, 50)];
+    drawParticles(ctx, particles as never[], '#ff0000', 5, 'circle');
+    expect(ctx.fill).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── shape: circle (default) ───────────────────────────────────────────────────
+
+describe('drawParticles – circle', () => {
+  it('calls arc() with full 2π sweep', () => {
+    const ctx = makeCtx();
+    drawParticles(ctx, [makeParticle(10, 20) as never], '#ff0000', 5, 'circle');
+    expect(ctx.arc).toHaveBeenCalledWith(10, 20, 5, 0, Math.PI * 2);
+  });
+
+  it('calls fill() once per drawn particle', () => {
+    const ctx = makeCtx();
+    const particles = [makeParticle(10, 20), makeParticle(30, 40)];
+    drawParticles(ctx, particles as never[], '#ff0000', 5, 'circle');
+    expect(ctx.fill).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── shape: square ─────────────────────────────────────────────────────────────
+
+describe('drawParticles – square', () => {
+  it('calls rect() centered on particle position', () => {
+    const ctx = makeCtx();
+    drawParticles(ctx, [makeParticle(50, 60) as never], '#ff0000', 8, 'square');
+    expect(ctx.rect).toHaveBeenCalledWith(42, 52, 16, 16);
+  });
+
+  it('does not call arc() for square shape', () => {
+    const ctx = makeCtx();
+    drawParticles(ctx, [makeParticle(10, 10) as never], '#ff0000', 5, 'square');
+    expect(ctx.arc).not.toHaveBeenCalled();
+  });
+});
+
+// ── shape: triangle ───────────────────────────────────────────────────────────
+
+describe('drawParticles – triangle', () => {
+  it('calls moveTo() and lineTo() to form the triangle', () => {
+    const ctx = makeCtx();
+    const r = 5;
+    drawParticles(ctx, [makeParticle(10, 20) as never], '#ff0000', r, 'triangle');
+    expect(ctx.moveTo).toHaveBeenCalledWith(10, 20 - r);
+    expect(ctx.lineTo).toHaveBeenCalledWith(10 + r * 0.866, 20 + r * 0.5);
+    expect(ctx.lineTo).toHaveBeenCalledWith(10 - r * 0.866, 20 + r * 0.5);
+    expect(ctx.closePath).toHaveBeenCalled();
+  });
+});
+
+// ── shape: star ───────────────────────────────────────────────────────────────
+
+describe('drawParticles – star', () => {
+  it('calls moveTo() once and lineTo() 9 times for a 5-spike star', () => {
+    const ctx = makeCtx();
+    drawParticles(ctx, [makeParticle(50, 50) as never], '#ff0000', 5, 'star');
+    expect(ctx.moveTo).toHaveBeenCalledTimes(1);
+    expect(ctx.lineTo).toHaveBeenCalledTimes(9);
+    expect(ctx.closePath).toHaveBeenCalled();
+  });
+});
+
+// ── shape: diamond ────────────────────────────────────────────────────────────
+
+describe('drawParticles – diamond', () => {
+  it('draws four points forming a diamond', () => {
+    const ctx = makeCtx();
+    const r = 6;
+    drawParticles(ctx, [makeParticle(20, 30) as never], '#ff0000', r, 'diamond');
+    expect(ctx.moveTo).toHaveBeenCalledWith(20, 30 - r);
+    expect(ctx.lineTo).toHaveBeenCalledWith(20 + r * 0.7, 30);
+    expect(ctx.lineTo).toHaveBeenCalledWith(20, 30 + r);
+    expect(ctx.lineTo).toHaveBeenCalledWith(20 - r * 0.7, 30);
+    expect(ctx.closePath).toHaveBeenCalled();
+  });
+});
+
+// ── shape: heart ──────────────────────────────────────────────────────────────
+
+describe('drawParticles – heart', () => {
+  it('calls bezierCurveTo() four times for the heart curves', () => {
+    const ctx = makeCtx();
+    drawParticles(ctx, [makeParticle(40, 40) as never], '#ff0000', 5, 'heart');
+    expect(ctx.bezierCurveTo).toHaveBeenCalledTimes(4);
+    expect(ctx.closePath).toHaveBeenCalled();
+  });
+});
+
+// ── shape: hat ────────────────────────────────────────────────────────────────
+
+describe('drawParticles – hat', () => {
+  it('calls rect() twice (crown + brim)', () => {
+    const ctx = makeCtx();
+    drawParticles(ctx, [makeParticle(30, 30) as never], '#ff0000', 10, 'hat');
+    expect(ctx.rect).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls fill() mid-shape for the crown, then again at end', () => {
+    const ctx = makeCtx();
+    drawParticles(ctx, [makeParticle(30, 30) as never], '#ff0000', 10, 'hat');
+    expect(ctx.fill).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── multiple particles ────────────────────────────────────────────────────────
+
+describe('drawParticles – multiple particles', () => {
+  it('calls beginPath() once per non-zero particle', () => {
+    const ctx = makeCtx();
+    const particles = [
+      makeParticle(0, 0),  // skipped
+      makeParticle(10, 10),
+      makeParticle(20, 20),
+    ];
+    drawParticles(ctx, particles as never[], '#ff0000', 5, 'circle');
+    expect(ctx.beginPath).toHaveBeenCalledTimes(2);
+  });
+
+  it('draws all shapes using the given particleSize as radius', () => {
+    const shapes: ParticleShape[] = ['circle', 'square', 'triangle', 'star', 'diamond', 'heart', 'hat'];
+    for (const shape of shapes) {
+      const ctx = makeCtx();
+      expect(() =>
+        drawParticles(ctx, [makeParticle(50, 50) as never], '#ff0', 7, shape)
+      ).not.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
Summary

  - Add test coverage for the renderer layer: drawParticles (all 7 particle shapes), canvasRenderer (drawGrid + drawNode with all 24 shapes), and drawEdge (all borderPoint
  math branches + drawEdge main function)
  - Add test coverage for the hook layer: useParticleSystem (particle count formula, Sankey min/max caps, reactivity), useEditorResize (drag delta calculation, width
  clamping, listener cleanup), and useCanvasTransform (canvasToWorld, zoom/pan/wheel, hover detection, fitToScreen)
  - Remove a duplicate test in drawParticles whose name contradicted its assertion (shadowBlur)

  Test plan

  - npm run test passes in full (37 test files, 947 tests)
  - No overlap with existing tests — verified via manual review and automated audit
  - useMermaidParser, useMediaRecorder, and React components are out of scope for this PR due to external environment dependencies (window.mermaid, MediaRecorder, Web
  Worker)