### PR TITLE
[fix] borderPoint() arrow contact offset for hexagon, stadium, and cyl…

### DIFF
--- a/src/test/renderers/drawEdge.borderPoint.shapes.test.ts
+++ b/src/test/renderers/drawEdge.borderPoint.shapes.test.ts
@@ -2,7 +2,9 @@
  * borderPoint coverage for shapes not covered by drawEdge.borderPoint.test.ts:
  * - ellipse branch: circle, cloud, bang
  * - L1-norm branch: diamond
- * - rect fallback: roundRect, stadium, note, hexagon, subroutine, cylinder
+ * - polygon branch: hexagon
+ * - capped branches: stadium (circular caps), cylinder (elliptical caps)
+ * - rect fallback: roundRect, note, subroutine, forkJoin
  */
 import { describe, it, expect } from 'vitest';
 import { borderPoint } from '../../utils/drawEdge';
@@ -132,13 +134,133 @@ describe('borderPoint – diamond (L1-norm formula)', () => {
   });
 });
 
+// ── polygon branch: hexagon ───────────────────────────────────────────────────
+
+describe('borderPoint – hexagon (6-vertex polygon)', () => {
+  // width=100, height=40 → hw=50, hh=20, tip=20
+  // vertices: (±30,∓20) top/bottom, (±50,0) left/right tips
+  const n = node('hexagon');
+
+  it('angle=0 (right): hits the right tip at x = +50', () => {
+    const pt = borderPoint(0, n);
+    expect(approx(pt.x, 50)).toBe(true);
+    expect(approx(pt.y, 0)).toBe(true);
+  });
+
+  it('angle=π (left): hits the left tip at x = -50', () => {
+    const pt = borderPoint(Math.PI, n);
+    expect(approx(pt.x, -50)).toBe(true);
+    expect(approx(pt.y, 0)).toBe(true);
+  });
+
+  it('angle=π/2 (down): y = +20', () => {
+    const pt = borderPoint(Math.PI / 2, n);
+    expect(approx(pt.y, 20)).toBe(true);
+    expect(approx(pt.x, 0)).toBe(true);
+  });
+
+  it('diagonal toward old rect corner lands on the slanted edge, not at (50,20)', () => {
+    // Ray toward the rect corner (50,20) must stop at the slanted edge x + y = 50
+    const pt = borderPoint(Math.atan2(20, 50), n);
+    expect(pt.x + pt.y).toBeCloseTo(50, 1);
+    expect(pt.x).toBeLessThan(50 - 5); // clearly inset from the rect corner
+  });
+
+  it('point always lies on the hexagon outline', () => {
+    for (const angle of [0.15, 0.6, 1.2, 2.1, 2.9, 3.6, 4.5, 5.7]) {
+      const { x, y } = borderPoint(angle, n);
+      const ax = Math.abs(x), ay = Math.abs(y);
+      // Either on the flat top/bottom edge, or on a slanted tip edge (|x| + |y| = hw)
+      const onFlat  = Math.abs(ay - 20) < 0.5 && ax <= 30 + 0.5;
+      const onSlant = Math.abs(ax + ay - 50) < 0.5;
+      expect(onFlat || onSlant).toBe(true);
+    }
+  });
+});
+
+// ── stadium: rect body + semicircular end caps ────────────────────────────────
+
+describe('borderPoint – stadium (semicircular caps)', () => {
+  // width=100, height=40 → hw=50, hh=20, cap circle centres at (±30, 0), r=20
+  const n = node('stadium');
+
+  it('angle=0 (right): x = +50', () => {
+    const pt = borderPoint(0, n);
+    expect(approx(pt.x, 50)).toBe(true);
+    expect(approx(pt.y, 0)).toBe(true);
+  });
+
+  it('angle=π/2 (down): y = +20', () => {
+    const pt = borderPoint(Math.PI / 2, n);
+    expect(approx(pt.y, 20)).toBe(true);
+    expect(approx(pt.x, 0)).toBe(true);
+  });
+
+  it('diagonal toward old rect corner lands on the cap arc, not at (50,20)', () => {
+    const pt = borderPoint(Math.atan2(20, 50), n);
+    expect((pt.x - 30) ** 2 + pt.y ** 2).toBeCloseTo(400, 0); // on the cap circle
+    expect(pt.x).toBeLessThan(50 - 5);
+  });
+
+  it('point always lies on the stadium outline', () => {
+    for (const angle of [0.15, 0.6, 1.2, 2.1, 2.9, 3.6, 4.5, 5.7]) {
+      const { x, y } = borderPoint(angle, n);
+      const ax = Math.abs(x);
+      if (ax <= 30) {
+        expect(Math.abs(y)).toBeCloseTo(20, 1); // flat top/bottom
+      } else {
+        expect((ax - 30) ** 2 + y ** 2).toBeCloseTo(400, 0); // cap circle
+      }
+    }
+  });
+});
+
+// ── cylinder: vertical sides + elliptical caps ────────────────────────────────
+
+describe('borderPoint – cylinder (elliptical caps)', () => {
+  // width=100, height=40 → hw=50, hh=20
+  // ry = max(6, 40·0.18) = 7.2, cap ellipse centres at (0, ±12.8), radii (50, 7.2)
+  const n = node('cylinder');
+  const ry = 7.2, capY = 12.8;
+
+  it('angle=0 (right): x = +50 (straight side)', () => {
+    const pt = borderPoint(0, n);
+    expect(approx(pt.x, 50)).toBe(true);
+    expect(approx(pt.y, 0)).toBe(true);
+  });
+
+  it('angle=π/2 (down): y = +20 (bottom of the lower cap)', () => {
+    const pt = borderPoint(Math.PI / 2, n);
+    expect(approx(pt.y, 20)).toBe(true);
+    expect(approx(pt.x, 0)).toBe(true);
+  });
+
+  it('diagonal toward old rect corner lands on the cap ellipse, not at (50,20)', () => {
+    const pt = borderPoint(Math.atan2(20, 50), n);
+    expect((pt.x / 50) ** 2 + ((pt.y - capY) / ry) ** 2).toBeCloseTo(1, 1);
+    expect(pt.x).toBeLessThan(50 - 1);
+  });
+
+  it('point always lies on the cylinder outline', () => {
+    for (const angle of [0.15, 0.6, 1.2, 2.1, 2.9, 3.6, 4.5, 5.7]) {
+      const { x, y } = borderPoint(angle, n);
+      const ay = Math.abs(y);
+      if (ay <= capY) {
+        expect(Math.abs(x)).toBeCloseTo(50, 1); // straight side
+      } else {
+        expect((x / 50) ** 2 + ((ay - capY) / ry) ** 2).toBeCloseTo(1, 1); // cap ellipse
+      }
+    }
+  });
+});
+
 // ── rect fallback: various shapes that share the rectangular border ───────────
 
 describe('borderPoint – rect-fallback shapes', () => {
   // All these shapes fall through to the default rectangle calculation:
   // t = min(hw / |dx|, hh / |dy|)
   const rectLike: DiagramNode['shape'][] = [
-    'roundRect', 'stadium', 'note', 'hexagon', 'subroutine', 'cylinder', 'forkJoin',
+    'roundRect', 'note', 'subroutine', 'forkJoin',
   ];
 
   for (const shape of rectLike) {

--- a/src/utils/drawEdge.ts
+++ b/src/utils/drawEdge.ts
@@ -40,6 +40,9 @@ const rayPolyIntersect = (
  * - diamond:           L1-norm border
  * - asymmetric:        pentagon (concave left notch)
  * - parallelogram/trapezoid variants: quadrilateral with skewed edges
+ * - hexagon:           6-vertex polygon (left/right tips at mid-height)
+ * - stadium:           rect body + semicircular end caps
+ * - cylinder:          vertical sides + elliptical top/bottom caps
  * - others:            rectangle border
  */
 export const borderPoint = (angle: number, node: DiagramNode): { x: number; y: number } => {
@@ -97,6 +100,60 @@ export const borderPoint = (angle: number, node: DiagramNode): { x: number; y: n
       [tl, t2], [tr, t2], [br, b], [bl, b],
     ]);
     if (pt) return pt;
+  }
+
+  if (shape === 'hexagon') {
+    // Tip inset matches canvasRenderer: hH/2 = hh
+    const tip = Math.min(hh, hw);
+    const l = cx - hw, r2 = cx + hw, t2 = cy - hh, b = cy + hh;
+    const pt = rayPolyIntersect(cx, cy, dx, dy, [
+      [l + tip,  t2],
+      [r2 - tip, t2],
+      [r2,       cy],
+      [r2 - tip, b],
+      [l + tip,  b],
+      [l,        cy],
+    ]);
+    if (pt) return pt;
+  }
+
+  if (shape === 'stadium') {
+    // Rect body + semicircular end caps of radius hh (matches roundRect radius height/2)
+    const cap = Math.max(hw - hh, 0); // x-offset of the cap circle centres
+    const ty2 = dy !== 0 ? hh / Math.abs(dy) : Infinity;
+    if (isFinite(ty2) && Math.abs(dx) * ty2 <= cap) {
+      return { x: cx + dx * ty2, y: cy + dy * ty2 }; // exits through the flat top/bottom
+    }
+    // Exits through the end circle centred at (±cap, 0):
+    // (dx·t − ccx)² + (dy·t)² = hh²  →  t² − 2(dx·ccx)t + ccx² − hh² = 0
+    const ccx = dx >= 0 ? cap : -cap;
+    const bHalf = dx * ccx;
+    const disc = bHalf * bHalf - (ccx * ccx - hh * hh);
+    if (disc >= 0) {
+      const t2 = bHalf + Math.sqrt(disc);
+      return { x: cx + dx * t2, y: cy + dy * t2 };
+    }
+  }
+
+  if (shape === 'cylinder') {
+    // Vertical sides + elliptical caps; cap ry matches canvasRenderer: max(6, height·0.18)
+    const ry = Math.max(6, height * 0.18);
+    const capY = Math.max(hh - ry, 0); // y-offset of the cap ellipse centres
+    const tx2 = dx !== 0 ? hw / Math.abs(dx) : Infinity;
+    if (isFinite(tx2) && Math.abs(dy) * tx2 <= capY) {
+      return { x: cx + dx * tx2, y: cy + dy * tx2 }; // exits through a straight side
+    }
+    // Exits through the cap ellipse centred at (0, ±capY) with radii (hw, ry):
+    // (dx·t/hw)² + ((dy·t − ccy)/ry)² = 1
+    const ccy = dy >= 0 ? capY : -capY;
+    const a = (dx / hw) ** 2 + (dy / ry) ** 2;
+    const bHalf = (dy * ccy) / (ry * ry);
+    const c = (ccy / ry) ** 2 - 1;
+    const disc = bHalf * bHalf - a * c;
+    if (a > 0 && disc >= 0) {
+      const t2 = (bHalf + Math.sqrt(disc)) / a;
+      return { x: cx + dx * t2, y: cy + dy * t2 };
+    }
   }
 
   const tx = dx !== 0 ? hw / Math.abs(dx) : Infinity;


### PR DESCRIPTION
…inder shapes

hexagon now uses rayPolyIntersect() with the 6 vertices matching canvasRenderer; stadium intersects the semicircular end caps exactly; cylinder intersects the straight sides and elliptical caps (ry = max(6, height*0.18)) matching the drawn outline.

Closes #42