### PR TITLE
[Fix] shape-aware hover hit-testing for non-rectangular nodes (#43)

### DIFF
--- a/src/hooks/useCanvasTransform.ts
+++ b/src/hooks/useCanvasTransform.ts
@@ -1,5 +1,6 @@
 import { useRef, useState, useCallback, useEffect } from 'react';
 import type { DiagramNode, Transform } from '../types';
+import { hitTestNode } from '../utils/canvasRenderer';
 
 interface UseCanvasTransformReturn {
   transformRef: React.MutableRefObject<Transform>;
@@ -145,32 +146,9 @@ export const useCanvasTransform = (
 
     let foundId: string | null = null;
     for (const node of nodes) {
-      if (node.shape === 'pie' && node.pieWedge) {
-        const { cx, cy, radius, startAngle, endAngle } = node.pieWedge;
-        const dx = mouseX - cx;
-        const dy = mouseY - cy;
-        if (Math.hypot(dx, dy) > radius) continue;
-        // Normalise mouse angle to [0, 2π) then check if it falls in the wedge sweep
-        let angle = Math.atan2(dy, dx);
-        let start = startAngle;
-        let end = endAngle;
-        // Normalise both to [0, 2π)
-        const TAU = Math.PI * 2;
-        angle = ((angle % TAU) + TAU) % TAU;
-        start = ((start % TAU) + TAU) % TAU;
-        end   = ((end   % TAU) + TAU) % TAU;
-        const inWedge = end >= start
-          ? angle >= start && angle <= end
-          : angle >= start || angle <= end; // wedge crosses the 0/2π boundary
-        if (inWedge) { foundId = node.id; break; }
-        continue;
-      }
-      if (
-        mouseX >= node.x - node.width / 2 &&
-        mouseX <= node.x + node.width / 2 &&
-        mouseY >= node.y - node.height / 2 &&
-        mouseY <= node.y + node.height / 2
-      ) {
+      // Shape-aware exact test (pie wedge sweep, diamond, hexagon, …) so the
+      // empty corners of non-rectangular shapes don't register as hover hits.
+      if (hitTestNode(node, mouseX, mouseY)) {
         foundId = node.id;
         break;
       }

--- a/src/test/renderers/canvasRenderer.findNodeAtPoint.test.ts
+++ b/src/test/renderers/canvasRenderer.findNodeAtPoint.test.ts
@@ -1,22 +1,18 @@
 /**
- * Tests for findNodeAtPoint — the shared snapping helper used by drawEdge
- * for all diagram types.
+ * Tests for hitTestNode + findNodeAtPoint.
  *
- * Snapping strategy
- * ─────────────────
- * Priority 1 — bbox hit: if (px,py) is inside the node box ±20 px, return
- *   that node.  Works for all diagram types when the path endpoint is on or
- *   very near the box border.
+ * hitTestNode — shape-aware exact hit test (issue #43). Mirrors the geometry
+ *   drawNode() paints: pie wedge sweep, diamond L1-norm, capsule stadium,
+ *   point-in-polygon for hexagon / parallelogram / trapezoid / asymmetric.
+ *   Used by useCanvasTransform.handleMouseMove for hover detection (pad=0).
  *
- * Priority 2 (exactOnly=false) — nearest-centre within 120 px: return the
- *   closest node whose centre is within 120 px.  This catches flowchart paths
- *   that end a few pixels outside the box.  Sequence edges use noSnap=true on
- *   the DiagramEdge so findNodeAtPoint is never called for them.
- *
- * When exactOnly=true the fallback is skipped entirely (bbox only).
+ * findNodeAtPoint — snapping wrapper built on hitTestNode:
+ *   Priority 1 — shape hit with pad=20 tolerance.
+ *   Priority 2 (exactOnly=false) — nearest-centre within 120 px.
+ *   When exactOnly=true the fallback is skipped entirely.
  */
 import { describe, it, expect } from 'vitest';
-import { findNodeAtPoint } from '../../utils/canvasRenderer';
+import { findNodeAtPoint, hitTestNode } from '../../utils/canvasRenderer';
 import type { DiagramNode } from '../../types';
 
 const makeNode = (
@@ -111,5 +107,109 @@ describe('findNodeAtPoint', () => {
     const node = makeNode({ x: 300, y: 100, width: 120, height: 60 });
     // Right border = 360; 360+15=375 is within pad=20
     expect(findNodeAtPoint([node], 375, 100, true)).toBe(node);
+  });
+});
+
+// All shape nodes below: centre (200,100), width 120, height 60 → hw=60, hh=30
+describe('hitTestNode — shape-aware exact tests (issue #43)', () => {
+  it('rect-like default: bbox corner still hits', () => {
+    const node = makeNode({ x: 200, y: 100, width: 120, height: 60 });
+    expect(hitTestNode(node, 255, 125)).toBe(true);
+  });
+
+  // ── diamond ────────────────────────────────────────────────────────────────
+  it('diamond: centre and vertices hit', () => {
+    const node = makeNode({ x: 200, y: 100, width: 120, height: 60, shape: 'diamond' });
+    expect(hitTestNode(node, 200, 100)).toBe(true);
+    expect(hitTestNode(node, 260, 100)).toBe(true); // right vertex, on edge
+    expect(hitTestNode(node, 200, 70)).toBe(true);  // top vertex
+  });
+
+  it('diamond: empty bbox corners no longer hit', () => {
+    const node = makeNode({ x: 200, y: 100, width: 120, height: 60, shape: 'diamond' });
+    // (250,120) is inside the bbox but outside the rhombus: 50/60 + 20/30 = 1.5 > 1
+    expect(hitTestNode(node, 250, 120)).toBe(false);
+    expect(hitTestNode(node, 150, 80)).toBe(false);
+  });
+
+  // ── circle family ──────────────────────────────────────────────────────────
+  it('circle: radial test rejects bbox corners', () => {
+    const node = makeNode({ x: 200, y: 100, width: 60, height: 60, shape: 'circle' });
+    expect(hitTestNode(node, 220, 100)).toBe(true);  // r=20 < 30
+    expect(hitTestNode(node, 225, 125)).toBe(false); // corner: r≈35 > 30
+  });
+
+  it('endCircle: same radial test', () => {
+    const node = makeNode({ x: 200, y: 100, width: 40, height: 40, shape: 'endCircle' });
+    expect(hitTestNode(node, 200, 118)).toBe(true);
+    expect(hitTestNode(node, 216, 116)).toBe(false); // corner: r≈22.6 > 20
+  });
+
+  // ── stadium ────────────────────────────────────────────────────────────────
+  it('stadium: capsule test rejects corners but keeps rounded ends', () => {
+    const node = makeNode({ x: 200, y: 100, width: 120, height: 60, shape: 'stadium' });
+    expect(hitTestNode(node, 142, 100)).toBe(true);  // left rounded end
+    expect(hitTestNode(node, 145, 75)).toBe(false);  // top-left bbox corner
+    expect(hitTestNode(node, 200, 128)).toBe(true);  // flat bottom of core
+  });
+
+  // ── hexagon ────────────────────────────────────────────────────────────────
+  it('hexagon: side tips hit, cut corners do not', () => {
+    const node = makeNode({ x: 200, y: 100, width: 120, height: 60, shape: 'hexagon' });
+    // vertices: (170,70)(230,70)(260,100)(230,130)(170,130)(140,100)
+    expect(hitTestNode(node, 255, 100)).toBe(true);  // near right tip
+    expect(hitTestNode(node, 145, 75)).toBe(false);  // cut top-left corner
+    expect(hitTestNode(node, 255, 128)).toBe(false); // cut bottom-right corner
+  });
+
+  // ── parallelogram / trapezoid ─────────────────────────────────────────────
+  it('parallelogram: skewed corners no longer hit', () => {
+    const node = makeNode({ x: 200, y: 100, width: 120, height: 60, shape: 'parallelogram' });
+    // skew=18 → vertices (158,70)(260,70)(242,130)(140,130)
+    expect(hitTestNode(node, 200, 100)).toBe(true);
+    expect(hitTestNode(node, 145, 72)).toBe(false);  // top-left skew gap
+    expect(hitTestNode(node, 255, 128)).toBe(false); // bottom-right skew gap
+  });
+
+  it('trapezoid: narrowed top corners no longer hit', () => {
+    const node = makeNode({ x: 200, y: 100, width: 120, height: 60, shape: 'trapezoid' });
+    // skew=18 → vertices (158,70)(242,70)(140,130)(260,130)
+    expect(hitTestNode(node, 145, 72)).toBe(false);
+    expect(hitTestNode(node, 255, 72)).toBe(false);
+    expect(hitTestNode(node, 145, 128)).toBe(true); // wide bottom edge
+  });
+
+  // ── asymmetric ────────────────────────────────────────────────────────────
+  it('asymmetric: left notch concavity no longer hits', () => {
+    const node = makeNode({ x: 200, y: 100, width: 120, height: 60, shape: 'asymmetric' });
+    // notch=27 → vertices (140,70)(260,70)(260,130)(140,130)(167,100)
+    expect(hitTestNode(node, 150, 100)).toBe(false); // inside the notch
+    expect(hitTestNode(node, 180, 100)).toBe(true);  // just past the notch tip
+    expect(hitTestNode(node, 145, 75)).toBe(true);   // top-left wing is solid
+    expect(hitTestNode(node, 255, 100)).toBe(true);  // flat right edge
+  });
+
+  // ── pie wedge ─────────────────────────────────────────────────────────────
+  it('pie wedge: hits inside the sweep, misses outside angle or radius', () => {
+    const node = makeNode({
+      x: 200, y: 100, width: 100, height: 100, shape: 'pie',
+      pieWedge: { cx: 200, cy: 100, radius: 50, startAngle: 0, endAngle: Math.PI / 2 },
+    });
+    expect(hitTestNode(node, 230, 130)).toBe(true);  // 45°, r≈42
+    expect(hitTestNode(node, 230, 70)).toBe(false);  // -45° outside sweep
+    expect(hitTestNode(node, 260, 160)).toBe(false); // r≈85 outside radius
+  });
+
+  // ── pad tolerance ─────────────────────────────────────────────────────────
+  it('pad inflates the shape outward (diamond)', () => {
+    const node = makeNode({ x: 200, y: 100, width: 120, height: 60, shape: 'diamond' });
+    expect(hitTestNode(node, 265, 100)).toBe(false);    // beyond right vertex
+    expect(hitTestNode(node, 265, 100, 20)).toBe(true); // within pad
+  });
+
+  it('pad inflates the shape outward (circle)', () => {
+    const node = makeNode({ x: 200, y: 100, width: 60, height: 60, shape: 'circle' });
+    expect(hitTestNode(node, 240, 100)).toBe(false);
+    expect(hitTestNode(node, 240, 100, 15)).toBe(true);
   });
 });

--- a/src/utils/canvasRenderer.ts
+++ b/src/utils/canvasRenderer.ts
@@ -725,6 +725,115 @@ export const drawNode = (
   }
 };
 
+/** Point-in-polygon (ray casting, even-odd) — also handles concave shapes like 'asymmetric'. */
+const pointInPolygon = (px: number, py: number, pts: Array<[number, number]>): boolean => {
+  let inside = false;
+  for (let i = 0, j = pts.length - 1; i < pts.length; j = i++) {
+    const [xi, yi] = pts[i];
+    const [xj, yj] = pts[j];
+    if ((yi > py) !== (yj > py) && px < ((xj - xi) * (py - yi)) / (yj - yi) + xi) {
+      inside = !inside;
+    }
+  }
+  return inside;
+};
+
+/**
+ * Shape-aware exact hit test for a single node, mirroring the geometry that
+ * drawNode() paints. `pad` inflates the shape outward for snapping tolerance.
+ *
+ * Vertices are derived from the node's parsed width/height; diamond and
+ * hexagon may be drawn slightly larger when a long label forces expansion,
+ * which this test intentionally ignores (the parsed bbox already reflects
+ * the label for Mermaid-produced nodes).
+ */
+export const hitTestNode = (n: DiagramNode, px: number, py: number, pad = 0): boolean => {
+  const dx = px - n.x;
+  const dy = py - n.y;
+  const hw = n.width / 2 + pad;
+  const hh = n.height / 2 + pad;
+
+  if (n.shape === 'pie' && n.pieWedge) {
+    const { cx, cy, radius, startAngle, endAngle } = n.pieWedge;
+    const wx = px - cx;
+    const wy = py - cy;
+    if (Math.hypot(wx, wy) > radius + pad) return false;
+    // Normalise mouse angle to [0, 2π) then check if it falls in the wedge sweep
+    const TAU = Math.PI * 2;
+    const angle = ((Math.atan2(wy, wx) % TAU) + TAU) % TAU;
+    const start = ((startAngle % TAU) + TAU) % TAU;
+    const end   = ((endAngle   % TAU) + TAU) % TAU;
+    return end >= start
+      ? angle >= start && angle <= end
+      : angle >= start || angle <= end; // wedge crosses the 0/2π boundary
+  }
+
+  switch (n.shape) {
+    case 'circle':
+    case 'endCircle':
+    case 'mergeCircle':
+    case 'reverseCircle':
+      return Math.hypot(dx, dy) <= n.width / 2 + pad;
+
+    case 'diamond':
+      // L1-norm: |dx|/hw + |dy|/hh <= 1 describes the rhombus
+      return Math.abs(dx) / hw + Math.abs(dy) / hh <= 1;
+
+    case 'stadium': {
+      // Capsule: rect core + semicircle ends, r = height/2
+      const r = n.height / 2;
+      const coreDx = Math.max(Math.abs(dx) - (n.width / 2 - r), 0);
+      return Math.hypot(coreDx, dy) <= r + pad;
+    }
+
+    case 'hexagon': {
+      const tip = hh;
+      return pointInPolygon(px, py, [
+        [n.x - hw + tip, n.y - hh],
+        [n.x + hw - tip, n.y - hh],
+        [n.x + hw,       n.y],
+        [n.x + hw - tip, n.y + hh],
+        [n.x - hw + tip, n.y + hh],
+        [n.x - hw,       n.y],
+      ]);
+    }
+
+    case 'parallelogram':
+    case 'parallelogramAlt':
+    case 'trapezoid':
+    case 'trapezoidAlt': {
+      const skew = (hh * 2) * 0.3;
+      const l = n.x - hw, r = n.x + hw;
+      const t = n.y - hh, b = n.y + hh;
+      let tl: number, tr: number, bl: number, br: number;
+      if (n.shape === 'parallelogram') {
+        tl = l + skew; tr = r;        bl = l;        br = r - skew;
+      } else if (n.shape === 'parallelogramAlt') {
+        tl = l;        tr = r - skew; bl = l + skew; br = r;
+      } else if (n.shape === 'trapezoid') {
+        tl = l + skew; tr = r - skew; bl = l;        br = r;
+      } else {
+        tl = l;        tr = r;        bl = l + skew; br = r - skew;
+      }
+      return pointInPolygon(px, py, [[tl, t], [tr, t], [br, b], [bl, b]]);
+    }
+
+    case 'asymmetric': {
+      // >text] : flat right edge, concave notch on the left pointing right
+      const notch = (hh * 2) * 0.45;
+      const l = n.x - hw, r = n.x + hw;
+      const t = n.y - hh, b = n.y + hh;
+      return pointInPolygon(px, py, [
+        [l, t], [r, t], [r, b], [l, b], [l + notch, n.y],
+      ]);
+    }
+
+    default:
+      // Rect-like shapes (rect, roundRect, subroutine, note, cylinder, …): bbox
+      return Math.abs(dx) <= hw && Math.abs(dy) <= hh;
+  }
+};
+
 export const findNodeAtPoint = (
   nodes: DiagramNode[],
   px: number, py: number,
@@ -732,11 +841,7 @@ export const findNodeAtPoint = (
 ): DiagramNode | null => {
   for (const n of nodes) {
     if (n.type === 'cluster') continue;
-    const pad = 20;
-    if (
-      px >= n.x - n.width  / 2 - pad && px <= n.x + n.width  / 2 + pad &&
-      py >= n.y - n.height / 2 - pad && py <= n.y + n.height / 2 + pad
-    ) return n;
+    if (hitTestNode(n, px, py, 20)) return n;
   }
   if (exactOnly) return null;
   let best: DiagramNode | null = null;


### PR DESCRIPTION
Extract hitTestNode(), a per-shape exact hit test mirroring drawNode() geometry: diamond L1-norm, radial circle family, capsule stadium, and point-in-polygon (ray casting, concave-safe) for hexagon / parallelogram / trapezoid / asymmetric. The pie wedge sweep test moves in from handleMouseMove.

handleMouseMove() now calls hitTestNode instead of a plain AABB, so the empty corners of non-rectangular shapes no longer register as hover hits. findNodeAtPoint() (snapping, pad=20 + nearest-centre fallback) is rebuilt on the same helper instead of staying dead code with its own bbox copy.

Fixes #43