### PR TITLE
fix: add missing required 'bold' to SeqLabel test fixtures

### DIFF
--- a/src/test/renderers/canvasRenderer.renderFrame.test.ts
+++ b/src/test/renderers/canvasRenderer.renderFrame.test.ts
@@ -330,7 +330,7 @@ describe('renderFrame – dark mode label backgrounds', () => {
   });
 
   const makeLabel = (bgColor: string) => ({
-    x: 100, y: 100, text: '呼叫', fontSize: 12,
+    x: 100, y: 100, text: '呼叫', fontSize: 12, bold: false,
     color: '#333333', align: 'center' as const, bgColor,
   });
 


### PR DESCRIPTION
tsc -b (the deploy build) checks the test project; the dark-mode label background fixtures were missing the required SeqLabel.bold field and broke the deploy on main.