### PR TITLE
[fix] detect diagram type through multi-line %%{init}%% directives

### DIFF
--- a/src/services/diagramTypes.ts
+++ b/src/services/diagramTypes.ts
@@ -14,7 +14,14 @@ export type DiagramType =
   | 'generic';
 
 export const getDiagramType = (code: string): DiagramType => {
-  let lines = code.trim().split('\n');
+  // Strip %%{...}%% directives first. These can span multiple lines (e.g. a
+  // multi-line init/themeVariables block), and only the opening line starts
+  // with %%, so a line-by-line "skip lines starting with %%" check would treat
+  // the directive's inner lines as the first meaningful line and misdetect the type.
+  let lines = code
+    .replace(/%%\{[\s\S]*?\}%%/g, '')
+    .trim()
+    .split('\n');
 
   // Skip YAML front-matter block (--- ... ---) used by Mermaid config directives
   if (lines[0]?.trim() === '---') {
@@ -22,7 +29,7 @@ export const getDiagramType = (code: string): DiagramType => {
     if (closingIdx > 0) lines = lines.slice(closingIdx + 1);
   }
 
-  // Skip %%{init: ...}%% directives and blank/comment lines
+  // Skip remaining %% comment lines and blank lines
   const firstMeaningfulLine = lines
     .map(l => l.trim())
     .find(l => l.length > 0 && !l.startsWith('%%'))

--- a/src/test/parsers/diagramTypes.test.ts
+++ b/src/test/parsers/diagramTypes.test.ts
@@ -87,6 +87,26 @@ describe('getDiagramType', () => {
     expect(getDiagramType(code)).toBe('flowchart');
   });
 
+  it('skips a multi-line %%{init}%% directive and reads the next meaningful line', () => {
+    const code = `%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#2d1b69',
+  'primaryTextColor': '#e0d4ff',
+  'fontFamily': 'ui-sans-serif, system-ui'
+}}}%%
+flowchart TD
+  A([使用者請求]) --> B{身份驗證}`;
+    expect(getDiagramType(code)).toBe('flowchart');
+  });
+
+  it('skips a multi-line %%{init}%% directive before a sequence diagram', () => {
+    const code = `%%{init: {
+  'theme': 'dark'
+}}%%
+sequenceDiagram
+  Alice->>Bob: Hello`;
+    expect(getDiagramType(code)).toBe('sequence');
+  });
+
   it('skips blank lines before the first keyword', () => {
     expect(getDiagramType('\n\n  \nsequenceDiagram')).toBe('sequence');
   });


### PR DESCRIPTION
getDiagramType skipped only lines starting with %%, so a multi-line init/themeVariables block left its inner lines (e.g. 'primaryColor': ...) as the first meaningful line, misdetecting the type as generic and routing flowcharts through the wrong parser.

Strip the entire %%{...}%% block (including newlines) before splitting into lines. Add tests covering multi-line init before flowchart and sequence diagrams.